### PR TITLE
Match lumium seed reward to all the other seed rewards

### DIFF
--- a/config/ftbquests/quests/chapters/mystical.snbt
+++ b/config/ftbquests/quests/chapters/mystical.snbt
@@ -1561,7 +1561,7 @@
 			rewards: [{
 				id: "495ABBEB3A29319B"
 				type: "item"
-				item: "thermal:lumium_dust"
+				item: "mysticalagriculture:lumium_essence"
 				count: 4
 			}]
 		}


### PR DESCRIPTION
All the Mystical Agriculture seed quests give essence as a reward--except for one: lumium. The essence is useful for creating storage filters before growing the seed, so I assume that this difference is unintentional. 

This PR brings the lumium quest reward into sync with all the others.